### PR TITLE
Add analog trend selection and plotting

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from ui.dashboard import render_dashboard
 from ui.overview import render_overview
 from ui.eds_cycles import render_eds_cycles
 from ui.pressure_cycles import render_pressure_cycles
+from ui.analog_trends import render_analog_trends
 from utils.colors import OC_COLORS, BY_COLORS, FLOW_COLORS, FLOW_CATEGORY_ORDER
 from logic.tag_maps import get_rig_tags
 from logic.data_loaders import get_pressure_df
@@ -43,7 +44,13 @@ params = st.query_params
 requested_rig = params.get("rig")
 requested_theme = params.get("theme")
 
-available_pages = ["Valve Analytics", "Pods Overview", "EDS Cycles", "Pressure Cycles"]
+available_pages = [
+    "Valve Analytics",
+    "Pods Overview",
+    "EDS Cycles",
+    "Pressure Cycles",
+    "Analog Trends",
+]
 requested_page = params.get("page")
 page_from_deeplink = requested_page if requested_page in available_pages else available_pages[0]
 
@@ -190,5 +197,12 @@ if df is not None and vol_df is not None:
             )
         else:
             st.warning("No well pressure data available for analysis.")
+    elif page == "Analog Trends":
+        render_analog_trends(
+            rig=rig,
+            default_start=start_date,
+            default_end=end_date,
+            template=plotly_template,
+        )
 else:
     st.info("Please click **Load Data** in the sidebar to get started.")

--- a/logic/analog_files/Drillmax.csv
+++ b/logic/analog_files/Drillmax.csv
@@ -1,0 +1,59 @@
+Ch,Analog Name,Min Raw,Max Raw,Min EU,Max EU,Type,Units,Deadband
+1,Annular Regulator Pilot Pressure,819,4095,0,850,pressure-hyd,psi,3
+2,Connector Regulator Pilot Pressure,819,4095,0,850,pressure-hyd,psi,3
+3,Solenoid Regulator Supply,819,4095,0,850,pressure-hyd,psi,3
+4,,819,4095,0,850,pressure-hyd,psi,3
+5,Subsea Supply Readback Pressure,819,4095,0,850,pressure-hyd,psi,3
+6,Solenoid Valve Supply Readback Pressure,819,4095,0,850,pressure-hyd,psi,3
+7,Conduit Supply Readback Pressure,819,4095,0,850,pressure-hyd,psi,3
+8,Annular Regulator Readback Pressure,819,4095,0,850,pressure-hyd,psi,3
+9,Hydrostatic Pressure #1,819,4095,0,850,hyd,psi,3
+10,Connector Regulator Readback Pressure,819,4095,0,850,Pressure-hyd,psi,3
+11,BOP Manifold Regulator Readback Pressure,819,4095,0,850,pressure-hyd,psi,3
+12,Connector Latch Pressure,819,4095,0,850,pressure-hyd,psi,3
+13,BOP Manifold Regulator Pilot Pressure,819,4095,0,850,pressure-hyd,psi,3
+14,Hydrostatic Pressure 2,819,4095,0,850,hyd2,psi,3
+15,Fail Safe Acc. Charge Readback,819,4095,0,850,pressure-hyd,psi,3
+16,,819,4095,0,850,pressure-hyd,psi,3
+17,,819,4095,0,850,,,3
+18,,819,4095,0,850,pressure-hyd,psi,3
+19,,819,4095,0,850,,psi,3
+20,,819,4095,0,850,pressure-hyd,psi,3
+21,Power Supply 1,819,4095,0,34,volts,volts,3
+22,Power Supply 2,819,4095,0,34,volts,volts,3
+23,Power Supply 3,819,4095,0,34,volts,volts,3
+24,,819,4095,0,850,raw,pulses,3
+25,Stack Inclination X-Direction,819,4095,-15,15,angle,degrees,3
+26,Stack Inclination Y-Direction,819,4095,-15,15,angle,degrees,3
+27,,819,4095,-14.5,14.5,angle,degrees,3
+28,,819,4095,-14.5,14.5,angle,degrees,3
+29,,819,4095,0,0,raw,raw,3
+30,,0,4095,0,0,,,3
+31,SEM Temperature,-400,1240,-40,124,temp,Degree,3
+32,SEM Humidity,0,1000,0,100,moist,Percent,3
+33,Riser Inclinometer X-Direction Blue Pod,819,4095,-15,15,angle,degrees,3
+34,Riser Inclinometer Y-Direction Blue Pod,819,4095,-15,15,angle,degrees,3
+35,,0,4095,0,0,,,3
+36,,0,4095,0,0,,,3
+37,,819,4095,0,1379,pressure-hyd,psi,3
+38,,819,4095,-40,200,temp,degrees,3
+39,,819,4095,0,1379,pressure-hyd,psi,3
+40,,819,4095,-40,200,temp,degrees,3
+41,Blue Flow Meter Input,819,4095,0,850,raw,pulses,0
+42,Riser Inclinometer X-Direction Yellow Pod,819,4095,-15,15,angle,degrees,3
+43,Riser Inclinometer Y-Direction Yellow Pod,819,4095,-15,15,angle,degrees,3
+44,BOP Pressure from Yellow RCB,819,4095,0,1379,pressure-hyd,psi,3
+45,BOP Temperature from Yellow RCB,819,4095,-40,200,temp,degrees,3
+46,BOP Acccumulator Pressure from Yellow RCB,819,4095,0,1034.19995,pressure-hyd,psi,3
+47,,819,4095,-40,200,temp,degrees,3
+48,,819,4095,0,1379,pressure-hyd,psi,3
+49,,819,4095,-40,200,temp,degrees,3
+50,Yellow Flowmeter ,819,4095,0,850,raw,pulses,0
+51,AMF Battery Voltage,25000,32500,25,32.5,Volts,volts,3
+52,AMF Battery Current,0,12000,-6,6,Amps,Amps,3
+53,AMF Battery Temperature,2631,3331,-10,60,temp,DegC,3
+54,Battery Capacity,6000,13000,0,7,Amps,A-Hour,3
+55,Conduit Pressure,819,4095,0,850,pressure-hyd,psi,3
+56,Hydrostatic Pressure,819,4095,0,850,Pressure,psi,3
+57,Status,0,1819,0,1819,raw,raw,3
+58,ARMED,50,920,50,920,raw,raw,0

--- a/logic/analog_loader.py
+++ b/logic/analog_loader.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import pandas as pd
+
+
+def load_analog_map(rig: str) -> pd.DataFrame | None:
+    """Load analog channel metadata for a given rig.
+
+    Parameters
+    ----------
+    rig : str
+        Rig identifier used in tag namespaces.
+
+    Returns
+    -------
+    pandas.DataFrame | None
+        DataFrame containing at least a ``Ch`` column with channel numbers and
+        an ``Analog Name`` column describing each channel. Returns ``None`` if
+        no mapping file exists for the requested rig.
+    """
+
+    base_dir = Path(__file__).resolve().parent / "analog_files"
+    file_path = base_dir / f"{rig}.csv"
+
+    if not file_path.exists():
+        return None
+
+    try:
+        return pd.read_csv(file_path)
+    except Exception:
+        # If the file is malformed, fall back to None so callers can decide
+        # how to handle missing metadata.
+        return None
+
+
+def build_tag(rig: str, channel: int) -> str:
+    """Return the external id for a given analog channel."""
+
+    if rig == "Drillmax":
+        base = f"pi-no:{rig}.BOP.CBM"
+    else:
+        base = f"pi-no:{rig}.BOP.DCP"
+    return f"{base}.ScaledValue{channel}"
+

--- a/ui/analog_trends.py
+++ b/ui/analog_trends.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timedelta
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from logic.analog_loader import load_analog_map, build_tag
+from logic.data_loaders import get_raw_df
+from logic.preprocessing import to_ms, downsample_for_display
+
+
+def _get_date_range(default_start: datetime, default_end: datetime):
+    """Render and return the date range selector for the trends page."""
+
+    value = st.date_input(
+        "Trend Date Range",
+        value=(default_start, default_end),
+        key="analog_trend_dates",
+    )
+
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return value[0], value[1]
+    return value, value
+
+
+def _select_channels(rig: str):
+    """Return list of selected channel numbers and mapping to labels."""
+
+    mapping_df = load_analog_map(rig)
+    if mapping_df is not None and not mapping_df.empty:
+        options = []
+        label_map: dict[int, str] = {}
+        for _, row in mapping_df.iterrows():
+            ch = int(row.get("Ch"))
+            name = str(row.get("Analog Name", "") or "").strip()
+            label = f"{ch} - {name}" if name else f"{ch}"
+            options.append(label)
+            label_map[ch] = label
+        selected_labels = st.multiselect("Select Analogs", options)
+        channels = [int(lbl.split(" - ")[0]) for lbl in selected_labels]
+    else:
+        options = [str(i) for i in range(1, 65)]
+        selected_labels = st.multiselect("Select Channels", options)
+        channels = [int(x) for x in selected_labels]
+        label_map = {ch: str(ch) for ch in channels}
+
+    return channels, label_map
+
+
+def render_analog_trends(rig: str, default_start: datetime, default_end: datetime, template: str):
+    """Render the Analog Trends page."""
+
+    st.header("Analog Trends")
+
+    start_date, end_date = _get_date_range(default_start, default_end)
+    channels, label_map = _select_channels(rig)
+
+    graph_type = st.selectbox("Graph Type", ["Line", "Scatter", "Area"])
+
+    if not channels:
+        st.info("Select one or more channels to display.")
+        return
+
+    sm = to_ms(start_date)
+    em = to_ms(end_date + timedelta(days=1)) - 1
+
+    frames = []
+    for ch in channels:
+        tag = build_tag(rig, ch)
+        df = get_raw_df(tag, sm, em)
+        if df.empty:
+            continue
+        df = df.rename(columns={df.columns[0]: "value"})
+        df.index = pd.to_datetime(df.index)
+        df = downsample_for_display(df)
+        df["channel"] = label_map.get(ch, str(ch))
+        frames.append(df)
+
+    if not frames:
+        st.warning("No data returned for selected channels.")
+        return
+
+    chart_df = pd.concat(frames).reset_index().rename(columns={"index": "timestamp"})
+
+    if graph_type == "Line":
+        fig = px.line(chart_df, x="timestamp", y="value", color="channel", template=template)
+    elif graph_type == "Scatter":
+        fig = px.scatter(chart_df, x="timestamp", y="value", color="channel", template=template)
+    else:  # Area
+        fig = px.area(chart_df, x="timestamp", y="value", color="channel", template=template)
+
+    st.plotly_chart(fig, use_container_width=True)
+

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -18,7 +18,13 @@ def render_sidebar(default_rig: str | None = None, default_page: str | None = No
     )
     rig = rigs[rig_labels.index(selected_label)]
 
-    all_pages = ["Valve Analytics", "Pods Overview", "EDS Cycles", "Pressure Cycles"]
+    all_pages = [
+        "Valve Analytics",
+        "Pods Overview",
+        "EDS Cycles",
+        "Pressure Cycles",
+        "Analog Trends",
+    ]
     page_index = all_pages.index(default_page) if default_page in all_pages else 0
     page = st.sidebar.radio("Select Page", all_pages, index=page_index, key="sidebar_page")
 


### PR DESCRIPTION
## Summary
- add page for trending analog channels with line, scatter, or area charts
- allow per-rig analog metadata via CSV files and tag builder
- enable selecting date range independent of sidebar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896375537dc8323bb8d4a92d1d2a160